### PR TITLE
stop filtering deleted records in ilios api requests.

### DIFF
--- a/ajax.php
+++ b/ajax.php
@@ -98,7 +98,7 @@ switch ($action) {
         $sid      = required_param('filterid', PARAM_INT); // school id
         $http = $enrol->get_http_client();
         $programs = array();
-        $programs = $http->get('programs', array('school' => $sid, 'deleted' => false), array('title' => "ASC"));
+        $programs = $http->get('programs', array('school' => $sid), array('title' => "ASC"));
         $programarray = array();
         foreach ($programs as $program) {
             $programarray["$program->id:$program->shortTitle:$program->title"] = $program->title;
@@ -110,7 +110,7 @@ switch ($action) {
         $pid    = required_param('filterid', PARAM_INT);
         $http = $enrol->get_http_client();
         $programyears = $http->get('programYears',
-                                              array("program" => $pid, "deleted" => false),
+                                              array("program" => $pid),
                                               array("startYear" => "ASC"));
         $programyeararray = array();
         $cohortoptions = array();

--- a/edit_form.php
+++ b/edit_form.php
@@ -282,11 +282,7 @@ class enrol_ilios_edit_form extends moodleform {
             $prog_el->load($schooloptions);
         } else {
             foreach ($schools as $school) {
-                if (isset($school->deleted) && $school->deleted) {
-                    $prog_el->addOption( $school->title, "$school->id:$school->title", array('disabled'=> 'true') );
-                } else {
-                    $prog_el->addOption( $school->title, "$school->id:$school->title" );
-                }
+                $prog_el->addOption( $school->title, "$school->id:$school->title" );
             }
         }
 
@@ -297,7 +293,7 @@ class enrol_ilios_edit_form extends moodleform {
             $programs = array();
             $programs = $http->get(
                 'programs',
-                array('school' => $sid, 'deleted' => false),
+                array('school' => $sid),
                 array('title' => "ASC")
             );
 
@@ -315,7 +311,7 @@ class enrol_ilios_edit_form extends moodleform {
             $cohortoptions = array();
 
             $programyears = $http->get('programYears',
-                                       array("program" => $pid, "deleted" => false),
+                                       array("program" => $pid),
                                        array("startYear" => "ASC"));
             $programyeararray = array();
             foreach ($programyears as $progyear) {


### PR DESCRIPTION
Ilios is doing away with the notion of soft-deletes, which comes with a schema change that's removing all 'deleted' columns from tables as applicable.
As a result, Ilios API won't be able to filter out 'deleted' records. API calls must be adjusted accordingly, this pull request provides the necessary code changes.

refs ilios/ilios#1087

On a related note, we are putting a temporary fix into the Ilios API backend that will strip out 'deleted' request parameters, this should ensure a seemless switch-over on the Ilios site without breaking this plugin. 