### PR TITLE
Unenroll disabled Ilios accounts

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -315,24 +315,25 @@ class enrol_ilios_plugin extends enrol_plugin {
                         } else {
                             $trace->output("skipping: Ilios user ".$user->id." does not have a 'campusId' field.", 1);
                         }
+                        continue;
+                    }
+
+                    $enrolleduserids[] = $userid = $iliosusers[$user->id]['id'];
+                    $status = ENROL_USER_ACTIVE;
+
+                    $ue = $DB->get_record('user_enrolments', array('enrolid' => $instance->id, 'userid' => $userid));
+
+                    // Continue if already enrolled with active status
+                    if (!empty($ue) && $status === (int) $ue->status) {
+                        continue;
+                    }
+
+                    // Enroll user
+                    $this->enrol_user($instance, $userid, $instance->roleid, 0, 0, $status);
+                    if (!empty($ue) && $status !== (int) $ue->status) {
+                        $trace->output("changing enrollment status to '{$status}' from '{$ue->status}': userid $userid ==> courseid ".$instance->courseid, 1);
                     } else {
-                        $enrolleduserids[] = $userid = $iliosusers[$user->id]['id'];
-                        $status = ENROL_USER_ACTIVE;
-
-                        $ue = $DB->get_record('user_enrolments', array('enrolid' => $instance->id, 'userid' => $userid));
-
-                        // Continue if already enrolled with active status
-                        if (!empty($ue) && $status === (int) $ue->status) {
-                            continue;
-                        }
-
-                        // Enroll user
-                        $this->enrol_user($instance, $userid, $instance->roleid, 0, 0, $status);
-                        if (!empty($ue) && $status !== (int) $ue->status) {
-                            $trace->output("changing enrollment status to '{$status}' from '{$ue->status}': userid $userid ==> courseid ".$instance->courseid, 1);
-                        } else {
-                            $trace->output("enrolling with $status status: userid $userid ==> courseid ".$instance->courseid, 1);
-                        }
+                        $trace->output("enrolling with $status status: userid $userid ==> courseid ".$instance->courseid, 1);
                     }
                 }
 

--- a/lib.php
+++ b/lib.php
@@ -297,6 +297,14 @@ class enrol_ilios_plugin extends enrol_plugin {
                 $trace->output(count($users) . " Ilios users found.");
 
                 foreach ($users as $user) {
+                    // Check if the given user is active in Ilios.
+                    // If not, then don't do anything here.
+                    // This will cause the enrolled users to become unenrolled further downstream,
+                    // Ilios users that are currently not enrolled will simply be ignored.
+                    if (! $user->enabled) {
+                        continue;
+                    }
+
                     // Fetch user info if not cached in $iliosusers
                     if (!isset($iliosusers[$user->id])) {
                         $iliosusers[$user->id] = null;


### PR DESCRIPTION
Check Ilios accounts during the enrollment sync process to for their activation status.
If the account is disabled then:
- do not enroll disabled accounts in the first place
- ~accounts that are currently enrolled will be unenrolled~
- depending on enrollment instance configuration, disabled ilios accounts that match currently enrolled user accounts in moodle will either have their enrollment _suspended_,  will be _unenrolled_, or nothing happens (should be the default for backwards compatibility purposes). add this configuration option. **[TODO ST 2019/09/24]**

fixes #31