### PR TITLE
fixes serialization issue with enrollment class.

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -37,18 +37,6 @@ require_once($CFG->libdir.'/filelib.php');
  */
 class enrol_ilios_plugin extends enrol_plugin {
     /**
-     * @var ilios The Ilios API client.
-     */
-    protected ilios $ilios;
-
-    /**
-     * Constructor.
-     */
-    public function __construct() {
-        $this->ilios = di::get(ilios::class);
-    }
-
-    /**
      * Is it possible to delete enrol instance via standard UI?
      *
      * @param stdClass $instance
@@ -206,6 +194,8 @@ class enrol_ilios_plugin extends enrol_plugin {
         global $CFG, $DB;
         require_once($CFG->dirroot . '/group/lib.php');
 
+        $ilios = di::get(ilios::class);
+
         if (!enrol_is_enabled('ilios')) {
             // Purge all roles if ilios sync disabled, those can be recreated later here by cron or CLI.
             $trace->output('Ilios enrolment sync plugin is disabled, unassigning all plugin roles and stopping.');
@@ -239,9 +229,9 @@ class enrol_ilios_plugin extends enrol_plugin {
             $syncid = $instance->customint1;
 
             if ('learnerGroup' === $synctype) {
-                $entity = $this->ilios->get_learner_group($syncid);
+                $entity = $ilios->get_learner_group($syncid);
             } else {
-                $entity = $this->ilios->get_cohort($syncid);
+                $entity = $ilios->get_cohort($syncid);
             }
 
             if (empty($entity)) {
@@ -257,7 +247,7 @@ class enrol_ilios_plugin extends enrol_plugin {
             if (!empty($instance->customint2)) {
                 $instructors = [];
                 if ('learnerGroup' === $synctype && !empty($instance->customint2)) {
-                    $instructors = $this->ilios->get_instructor_ids_from_learner_group($entity->id);
+                    $instructors = $ilios->get_instructor_ids_from_learner_group($entity->id);
                 }
                 if (!empty($instructors)) {
                     $trace->output(
@@ -269,7 +259,7 @@ class enrol_ilios_plugin extends enrol_plugin {
                         . $instance->id
                         . "."
                     );
-                    $users = $this->ilios->get_users(['id' => $instructors]);
+                    $users = $ilios->get_users(['id' => $instructors]);
                 }
             } else if (!empty($entity->users)) {
                 $trace->output(
@@ -281,7 +271,7 @@ class enrol_ilios_plugin extends enrol_plugin {
                     $instance->id
                     . "."
                 );
-                $users = $this->ilios->get_users(['id' => $entity->users]);
+                $users = $ilios->get_users(['id' => $entity->users]);
             }
             $trace->output(count($users) . " Ilios users found.");
 


### PR DESCRIPTION
Running Moodle-core test coverage with this enrollment plugin integrated causes several failures, all with a `Exception: Serialization of 'Closure' is not allowed`.

Here is one example:
```bash
stefan@nichtsnutz: ~/dev/projects/moodle44 on MOODLE_404_STABLE[?]
$ vendor/bin/phpunit --filter=test_data_saved admin/tool/uploadcourse/tests/course_test.php
Moodle 4.4.4+ (Build: 20241101), 99b5729824524e0bdc6a64ff1b0e4423d1d4b37a
Php: 8.3.13, mysqli: 8.0.39, OS: Linux 6.8.0-48-generic x86_64
PHPUnit 9.6.18 by Sebastian Bergmann and contributors.

E                                                                   1 / 1 (100%)

Time: 00:44.495, Memory: 82.50 MB

There was 1 error:

1) tool_uploadcourse\course_test::test_data_saved
Exception: Serialization of 'Closure' is not allowed

/home/stefan/dev/projects/moodle44/cache/stores/static/lib.php:243
/home/stefan/dev/projects/moodle44/cache/stores/static/lib.php:338
/home/stefan/dev/projects/moodle44/cache/classes/loaders.php:903
/home/stefan/dev/projects/moodle44/cache/classes/loaders.php:826
/home/stefan/dev/projects/moodle44/admin/tool/uploadcourse/classes/helper.php:184
/home/stefan/dev/projects/moodle44/admin/tool/uploadcourse/classes/helper.php:161
/home/stefan/dev/projects/moodle44/admin/tool/uploadcourse/classes/course.php:821
/home/stefan/dev/projects/moodle44/admin/tool/uploadcourse/tests/course_test.php:535
/home/stefan/dev/projects/moodle44/lib/phpunit/classes/advanced_testcase.php:76

ERRORS!
Tests: 1, Assertions: 5, Errors: 1.

```

Using a step-through debugger, I was able to pinpoint the problem - the Ilios API client cannot be set as class member during serialization, since brings in closures of the underlying HTTP client (Guzzle).

See screenshot below with highlighted closures:

![image](https://github.com/user-attachments/assets/116f5bab-7eb4-458f-8f50-4a2aed362ddc)


I'm side-stepping this issue by getting the client inside the only function that's actually using it. that get's around this problem since [the methods in an object will not be saved, only the name of the class](https://www.php.net/manual/en/language.oop5.serialization.php).


after the change/for comparison:

![image](https://github.com/user-attachments/assets/28629884-1440-4ef8-960c-590294035127)





