### PR TITLE
implements request batching

### DIFF
--- a/classes/ilios.php
+++ b/classes/ilios.php
@@ -79,8 +79,7 @@ class ilios {
      * @throws moodle_exception
      */
     public function get_schools(array $filterby = [], array $sortby = []): array {
-        $response = $this->get('schools', $filterby, $sortby);
-        return $response->schools;
+        return $this->get('schools', 'schools', $filterby, $sortby);
     }
 
     /**
@@ -93,8 +92,7 @@ class ilios {
      * @throws moodle_exception
      */
     public function get_cohorts(array $filterby = [], array $sortby = []): array {
-        $response = $this->get('cohorts', $filterby, $sortby);
-        return $response->cohorts;
+        return $this->get('cohorts', 'cohorts', $filterby, $sortby);
     }
 
     /**
@@ -107,8 +105,7 @@ class ilios {
      * @throws moodle_exception
      */
     public function get_programs(array $filterby = [], array $sortby = []): array {
-        $response = $this->get('programs', $filterby, $sortby);
-        return $response->programs;
+        return $this->get('programs', 'programs', $filterby, $sortby);
     }
 
     /**
@@ -121,8 +118,7 @@ class ilios {
      * @throws moodle_exception
      */
     public function get_program_years(array $filterby = [], array $sortby = []): array {
-        $response = $this->get('programyears', $filterby, $sortby);
-        return $response->programYears;
+        return $this->get('programyears', 'programYears', $filterby, $sortby);
     }
 
     /**
@@ -135,8 +131,7 @@ class ilios {
      * @throws moodle_exception
      */
     public function get_learner_groups(array $filterby = [], array $sortby = []): array {
-        $response = $this->get('learnergroups', $filterby, $sortby);
-        return $response->learnerGroups;
+        return $this->get('learnergroups', 'learnerGroups', $filterby, $sortby);
     }
 
     /**
@@ -149,8 +144,7 @@ class ilios {
      * @throws moodle_exception
      */
     public function get_instructor_groups(array $filterby = [], array $sortby = []): array {
-        $response = $this->get('instructorgroups', $filterby, $sortby);
-        return $response->instructorGroups;
+        return $this->get('instructorgroups', 'instructorGroups', $filterby, $sortby);
     }
 
     /**
@@ -163,8 +157,7 @@ class ilios {
      * @throws moodle_exception
      */
     public function get_offerings(array $filterby = [], array $sortby = []): array {
-        $response = $this->get('offerings', $filterby, $sortby);
-        return $response->offerings;
+        return $this->get('offerings', 'offerings', $filterby, $sortby);
     }
 
     /**
@@ -177,8 +170,7 @@ class ilios {
      * @throws moodle_exception
      */
     public function get_ilms(array $filterby = [], array $sortby = []): array {
-        $response = $this->get('ilmsessions', $filterby, $sortby);
-        return $response->ilmSessions;
+        return $this->get('ilmsessions', 'ilmSessions', $filterby, $sortby);
     }
 
     /**
@@ -191,8 +183,7 @@ class ilios {
      * @throws moodle_exception
      */
     public function get_users(array $filterby = [], array $sortby = []): array {
-        $response = $this->get('users', $filterby, $sortby);
-        return $response->users;
+        return $this->get('users', 'users', $filterby, $sortby);
     }
 
     /**
@@ -204,11 +195,7 @@ class ilios {
      * @throws moodle_exception
      */
     public function get_school(int $id): ?object {
-        $response = $this->get_by_id('schools', $id);
-        if ($response) {
-            return $response->schools[0];
-        }
-        return null;
+        return $this->get_by_id('schools', 'schools', $id);
     }
 
     /**
@@ -220,11 +207,7 @@ class ilios {
      * @throws moodle_exception
      */
     public function get_cohort(int $id): ?object {
-        $response = $this->get_by_id('cohorts', $id);
-        if ($response) {
-            return $response->cohorts[0];
-        }
-        return null;
+        return $this->get_by_id('cohorts', 'cohorts', $id);
     }
 
     /**
@@ -236,11 +219,7 @@ class ilios {
      * @throws moodle_exception
      */
     public function get_program(int $id): ?object {
-        $response = $this->get_by_id('programs', $id);
-        if ($response) {
-            return $response->programs[0];
-        }
-        return null;
+        return $this->get_by_id('programs', 'programs', $id);
     }
 
     /**
@@ -252,11 +231,7 @@ class ilios {
      * @throws moodle_exception
      */
     public function get_learner_group(int $id): ?object {
-        $response = $this->get_by_id('learnergroups', $id);
-        if ($response) {
-            return $response->learnerGroups[0];
-        }
-        return null;
+        return $this->get_by_id('learnergroups', 'learnerGroups', $id);
     }
 
     /**
@@ -347,17 +322,19 @@ class ilios {
      * Sends a GET request to a given API endpoint with given options.
      *
      * @param string $path The target path fragment of the API request URL. May include query parameters.
+     * @param string $key The name of the property that holds the requested data points in the payload.
      * @param array $filterby An associative array of filter options.
      * @param array $sortby An associative array of sort options.
-     * @return object The decoded response body.
+     * @return array The data points from the decoded payload.
      * @throws GuzzleException
      * @throws moodle_exception
      */
     public function get(
         string $path,
+        string $key,
         array $filterby = [],
         array $sortby = [],
-    ): object {
+    ): array {
         $this->validate_access_token($this->accesstoken);
         $options = ['headers' => ['X-JWT-Authorization' => 'Token ' . $this->accesstoken]];
 
@@ -389,7 +366,15 @@ class ilios {
         }
 
         $response = $this->httpclient->get($url, $options);
-        return $this->parse_result($response->getBody());
+        $rhett = $this->parse_result($response->getBody());
+        if (!property_exists($rhett, $key)) {
+            throw new moodle_exception(
+                'errorresponseentitynotfound',
+                'enrol_ilios',
+                a: $key,
+            );
+        }
+        return $rhett->$key;
     }
 
     /**
@@ -415,6 +400,7 @@ class ilios {
      * Retrieves a given resource from Ilios by its given ID.
      *
      * @param string $path The URL path fragment that names the resource.
+     * @param string $key The name of the property that holds the requested data points in the payload.
      * @param int $id The ID.
      * @param bool $returnnullonnotfound If TRUE then NULL is returned if the resource cannot be found.
      *                                      On FALSE, an exception is raised on 404/Not-Found.
@@ -423,9 +409,10 @@ class ilios {
      * @throws GuzzleException
      * @throws moodle_exception
      */
-    public function get_by_id(string $path, int $id, bool $returnnullonnotfound = true): ?object {
+    public function get_by_id(string $path, string $key, int $id, bool $returnnullonnotfound = true): ?object {
         try {
-            return $this->get($path . '/' . $id);
+            $response = $this->get($path . '/' . $id, $key);
+            return $response[0];
         } catch (ClientException $e) {
             if ($returnnullonnotfound && (404 === $e->getResponse()->getStatusCode())) {
                 return null;


### PR DESCRIPTION
fixes #69 

i decided to apply chunking/batching on all requests if applicable, not just for users requests.

note on the reduced request params limit - 250 is on the safe side, [1000](https://github.com/ilios/local_iliosapiclient/blob/574bcb56f5e282aae284a7f7da8bb9a655c4ccd0/classes/ilios_client.php#L193) was not.

for context - the previous, cURL-based HTTP client in use was _not_ encoding request parameters, whereas the new, Guzzle-based HTTP client does. which makes for much more verbose URLs.

for example, see these logged requests on the server-side:

Moodle 4.3, cURL client (ignore the `limit` query param)
`GET /api/v3/users?limit=1000&filters[id][]=4520&filters[id][]=7572&filters[id][]=7584&filters[id][]=7616&filters[id][]=7634&filters[id][]=7655&filters[id][]=7674&filters[id][]=7794...`

vs Moodle 4.4, Guzzle client

`GET /api/v3/users?filters%5Bid%5D%5B%5D=4520&filters%5Bid%5D%5B%5D=7572&filters%5Bid%5D%5B%5D=7584&filters%5Bid%5D%5B%5D=7616&filters%5Bid%5D%5B%5D=7634&filters%5Bid%5D%5B%5D=7655&filters%5Bid%5D%5B%5D=7674&filters%5Bid%5D%5B%5D=7794...`


