### PR TITLE
fixed code linting errors.

### DIFF
--- a/ajax.php
+++ b/ajax.php
@@ -32,8 +32,8 @@ use enrol_ilios\ilios;
 define('AJAX_SCRIPT', true);
 
 require('../../config.php');
-require_once($CFG->dirroot.'/enrol/locallib.php');
-require_once($CFG->dirroot.'/group/lib.php');
+require_once($CFG->dirroot . '/enrol/locallib.php');
+require_once($CFG->dirroot . '/group/lib.php');
 
 // Must have the sesskey.
 $id      = required_param('id', PARAM_INT); // Course ID.
@@ -112,8 +112,8 @@ switch ($action) {
             $cohorts = $ilios->get_cohorts(["programYear" => $programyeararray], ["title" => "ASC"]);
             foreach ($cohorts as $cohort) {
                 $cohortoptions["$cohort->id:$cohort->title"] = $cohort->title
-                                                             .' ('.count($cohort->learnerGroups).')'
-                                                             .' ('.count($cohort->users).')';
+                                                             . ' (' . count($cohort->learnerGroups) . ')'
+                                                             . ' (' . count($cohort->users) . ')';
             }
         }
         $outcome->response = $cohortoptions;
@@ -126,9 +126,9 @@ switch ($action) {
         $learnergroups = $ilios->get_learner_groups(['cohort' => $cid, 'parent' => 'null'], ['title' => "ASC"]);
         $grouparray = [];
         foreach ($learnergroups as $group) {
-            $grouparray["$group->id:$group->title"] = $group->title.
-                                                    ' ('. count($group->children) .')';
-            $grouparray["$group->id:$group->title"] .= ' ('. count($group->users) .')';
+            $grouparray["$group->id:$group->title"] = $group->title .
+                                                    ' (' . count($group->children) . ')';
+            $grouparray["$group->id:$group->title"] .= ' (' . count($group->users) . ')';
         }
         $outcome->response = $grouparray;
         break;
@@ -140,17 +140,17 @@ switch ($action) {
         $subgroupoptions = [];
         $subgroups = $ilios->get_learner_groups(["parent" => $gid], ["title" => "ASC"]);
         foreach ($subgroups as $subgroup) {
-            $subgroupoptions["$subgroup->id:$subgroup->title"] = $subgroup->title.
-                                                               ' ('. count($subgroup->children) .')';
-            $subgroupoptions["$subgroup->id:$subgroup->title"] .= ' ('. count($subgroup->users) .')';
+            $subgroupoptions["$subgroup->id:$subgroup->title"] = $subgroup->title .
+                                                               ' (' . count($subgroup->children) . ')';
+            $subgroupoptions["$subgroup->id:$subgroup->title"] .= ' (' . count($subgroup->users) . ')';
 
             if (!empty($subgroup->children)) {
                 $processchildren = function ($parent) use (&$processchildren, &$subgroupoptions, $ilios) {
                     $subgrps = $ilios->get_learner_groups([ 'parent' => $parent->id], [ 'title' => "ASC"]);
                     foreach ($subgrps as $subgrp) {
-                        $subgroupoptions["$subgrp->id:$parent->title / $subgrp->title"] = $parent->title.' / '.$subgrp->title.
-                                                                                        ' ('. count($subgrp->children) .')';
-                        $subgroupoptions["$subgrp->id:$parent->title / $subgrp->title"] .= ' ('. count($subgrp->users) .')';
+                        $subgroupoptions["$subgrp->id:$parent->title / $subgrp->title"] = $parent->title . ' / ' . $subgrp->title .
+                                                                                        ' (' . count($subgrp->children) . ')';
+                        $subgroupoptions["$subgrp->id:$parent->title / $subgrp->title"] .= ' (' . count($subgrp->users) . ')';
 
                         if (!empty($grp->children)) {
                             $processchildren($subgrp);

--- a/classes/ilios.php
+++ b/classes/ilios.php
@@ -39,7 +39,6 @@ use moodle_exception;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class ilios {
-
     /**
      * @var string The API base path.
      */

--- a/classes/task/ilios_sync_task.php
+++ b/classes/task/ilios_sync_task.php
@@ -35,7 +35,6 @@ use core\task\scheduled_task;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class ilios_sync_task extends scheduled_task {
-
     /**
      * Gets the task name.
      *

--- a/classes/tests/helper.php
+++ b/classes/tests/helper.php
@@ -37,7 +37,6 @@ use Firebase\JWT\JWT;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class helper {
-
     /**
      * Generates an un-expired JWT, to be used as access token.
      * This token will pass client-side token validation.

--- a/edit.php
+++ b/edit.php
@@ -55,7 +55,6 @@ $enrol = enrol_get_plugin('ilios');
 
 if ($instanceid) {
     $instance = $DB->get_record('enrol', ['courseid' => $course->id, 'enrol' => 'ilios', 'id' => $instanceid], '*', MUST_EXIST);
-
 } else {
     // No instance yet, we have to add new instance.
     if (!$enrol->get_newinstance_link($course->id)) {
@@ -83,7 +82,6 @@ $mform = new enrol_ilios_edit_form(null, [$instance, $enrol, $course, $ilios]);
 
 if ($mform->is_cancelled()) {
     redirect($returnurl);
-
 } else if ($data = $mform->get_data()) {
     // We are here only because the form is submitted.
     $synctype = '';
@@ -92,19 +90,19 @@ if ($mform->is_cancelled()) {
 
     $selectvalue = isset($data->selectschool) ? $data->selectschool : '';
     if (!empty($selectvalue)) {
-        list($schoolid, $schooltitle) = explode( ":", $selectvalue, 2);
+        [$schoolid, $schooltitle] = explode(":", $selectvalue, 2);
         $syncinfo["school"] = ["id" => $schoolid, "title" => $schooltitle];
     }
 
     $selectvalue = isset($data->selectprogram) ? $data->selectprogram : '';
     if (!empty($selectvalue)) {
-        list($programid, $programshorttitle, $programtitle) = explode( ":", $selectvalue, 3);
+        [$programid, $programshorttitle, $programtitle] = explode(":", $selectvalue, 3);
         $syncinfo["program"] = ["id" => $programid, "shorttitle" => $programshorttitle, "title" => $programtitle];
     }
 
     $selectvalue = isset($data->selectcohort) ? $data->selectcohort : '';
     if (!empty($selectvalue)) {
-        list($cohortid, $cohorttitle) = explode( ":", $selectvalue, 2);
+        [$cohortid, $cohorttitle] = explode(":", $selectvalue, 2);
         $synctype = 'cohort';
         $syncid = $cohortid;
         $syncinfo["cohort"] = ["id" => $cohortid, "title" => $cohorttitle];
@@ -112,7 +110,7 @@ if ($mform->is_cancelled()) {
 
     $selectvalue = isset($data->selectlearnergroup) ? $data->selectlearnergroup : '';
     if (!empty($selectvalue)) {
-        list($learnergroupid, $learnergrouptitle) = explode( ":", $selectvalue, 2);
+        [$learnergroupid, $learnergrouptitle] = explode(":", $selectvalue, 2);
         $synctype = 'learnerGroup';
         $syncid = $learnergroupid;
         $syncinfo["learnerGroup"] = [ "id" => $learnergroupid, "title" => $learnergrouptitle ];
@@ -120,7 +118,7 @@ if ($mform->is_cancelled()) {
 
     $selectvalue = isset($data->selectsubgroup) ? $data->selectsubgroup : '';
     if (!empty($selectvalue)) {
-        list($subgroupid, $subgrouptitle) = explode( ":", $selectvalue, 2);
+        [$subgroupid, $subgrouptitle] = explode(":", $selectvalue, 2);
         $synctype = 'learnerGroup';
         $syncid = $subgroupid;
         $syncinfo["subGroup"] = [ "id" => $subgroupid, "title" => $subgrouptitle ];
@@ -145,7 +143,7 @@ if ($mform->is_cancelled()) {
         $instance->roleid       = $data->roleid;
         $instance->customchar1  = $synctype;
         $instance->customint1   = $syncid;
-        $instance->customint2   = $data->selectusertype;;
+        $instance->customint2   = $data->selectusertype;
         $instance->customtext1  = json_encode($syncinfo);
         $instance->customint6   = $data->customint6;
         $instance->timemodified = time();

--- a/edit_form.php
+++ b/edit_form.php
@@ -40,7 +40,6 @@ require_once("lib.php");
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class enrol_ilios_edit_form extends moodleform {
-
     /**
      * Form definition.
      *
@@ -54,7 +53,7 @@ class enrol_ilios_edit_form extends moodleform {
 
         $mform  = $this->_form;
         /* @var enrol_ilios_plugin $plugin This enrolment plugin. */
-        list($instance, $plugin, $course, $ilios) = $this->_customdata;
+        [$instance, $plugin, $course, $ilios] = $this->_customdata;
         $coursecontext = context_course::instance($course->id);
 
         $enrol = $plugin;
@@ -108,8 +107,8 @@ class enrol_ilios_edit_form extends moodleform {
             $instance->selectcohortindex = "$instance->cohortid:$cohort->title";
             $cohortoptions = [ $instance->selectcohortindex =>
                                     $cohort->title
-                                    .' ('.count($cohort->learnerGroups).')'
-                                    .' ('.count($cohort->users).')'];
+                                    . ' (' . count($cohort->learnerGroups) . ')'
+                                    . ' (' . count($cohort->users) . ')'];
 
             $instance->learnergroupid = '';
             $instance->selectlearnergroupindex = '';
@@ -122,9 +121,9 @@ class enrol_ilios_edit_form extends moodleform {
 
                 if ($group) {
                     $instance->selectlearnergroupindex = "$instance->learnergroupid:$group->title";
-                    $grouptitle = $group->title.
-                        ' ('. count($group->children) .')';
-                    $grouptitle .= ' ('. count($group->users) .')';
+                    $grouptitle = $group->title .
+                        ' (' . count($group->children) . ')';
+                    $grouptitle .= ' (' . count($group->users) . ')';
                     $learnergroupoptions = [$instance->selectlearnergroupindex => $grouptitle];
 
                     if (!empty($group->parent)) {
@@ -142,7 +141,7 @@ class enrol_ilios_edit_form extends moodleform {
                                 "$instance->learnergroupid:$parentgroup->title" => $parentgroup->title,
                             ];
                             if (!empty($parentgroup->parent)) {
-                                $grouptitle = $parentgroup->title . ' / '. $grouptitle;
+                                $grouptitle = $parentgroup->title . ' / ' . $grouptitle;
                                 $processparents($parentgroup);
                             }
                         };
@@ -158,8 +157,7 @@ class enrol_ilios_edit_form extends moodleform {
         } else {
             $PAGE->requires->js_call_amd('enrol_ilios/main', 'init', [
                     $course->id,
-                ],
-            );
+                ]);
         }
 
         $mform->addElement('select', 'selectusertype', get_string('selectusertype', 'enrol_ilios'), $usertypes);
@@ -183,7 +181,6 @@ class enrol_ilios_edit_form extends moodleform {
         if ($instance->id) {
             $mform->setConstant('selectprogram', $instance->selectprogramindex);
             $mform->hardFreeze('selectprogram');
-
         } else {
             $mform->addRule('selectprogram', get_string('required'), 'required', null, 'client');
             $mform->disabledIf('selectprogram', 'selectschool', 'eq', '');
@@ -194,7 +191,6 @@ class enrol_ilios_edit_form extends moodleform {
         if ($instance->id) {
             $mform->setConstant('selectcohort', $instance->selectcohortindex);
             $mform->hardFreeze('selectcohort');
-
         } else {
             $mform->addRule('selectcohort', get_string('required'), 'required', null, 'client');
             $mform->disabledIf('selectcohort', 'selectprogram', 'eq', '');
@@ -205,7 +201,6 @@ class enrol_ilios_edit_form extends moodleform {
         if ($instance->id) {
             $mform->setConstant('selectlearnergroup', $instance->selectlearnergroupindex);
             $mform->hardFreeze('selectlearnergroup');
-
         } else {
             $mform->disabledIf('selectlearnergroup', 'selectcohort', 'eq', '');
         }
@@ -289,14 +284,14 @@ class enrol_ilios_edit_form extends moodleform {
             return;
         }
 
-        list($instance, $enrol, $course, $ilios) = $this->_customdata;
+        [$instance, $enrol, $course, $ilios] = $this->_customdata;
 
         $selectvalues = $mform->getElementValue('selectschool');
         if (is_array($selectvalues)) {
             if (strstr($selectvalues[0], ':')) {
-                list($schoolid, $schooltitle) = explode(':', $selectvalues[0], 2);
+                [$schoolid, $schooltitle] = explode(':', $selectvalues[0], 2);
             } else {
-                list($schoolid, $schooltitle) = [$selectvalues[0], '', ''];
+                [$schoolid, $schooltitle] = [$selectvalues[0], '', ''];
             }
         } else {
             $schoolid = '';
@@ -306,21 +301,21 @@ class enrol_ilios_edit_form extends moodleform {
         $selectvalues = $mform->getElementValue('selectprogram');
         if (is_array($selectvalues)) {
             if (strstr($selectvalues[0], ':')) {
-                list($programid, $programshorttitle, $programtitle) = explode(':', $selectvalues[0], 3);
+                [$programid, $programshorttitle, $programtitle] = explode(':', $selectvalues[0], 3);
             } else {
-                list($programid, $programshorttitle, $programtitle)
+                [$programid, $programshorttitle, $programtitle]
                     = [ $selectvalues[0], '', ''];
             }
         } else {
-                list($programid, $programshorttitle, $programtitle) = [ '', '', ''];
+                [$programid, $programshorttitle, $programtitle] = [ '', '', ''];
         }
 
         $selectvalues = $mform->getElementValue('selectcohort');
         if (is_array($selectvalues)) {
             if (strstr($selectvalues[0], ':')) {
-                list($cohortid, $cohorttitle) = explode(':', $selectvalues[0], 2);
+                [$cohortid, $cohorttitle] = explode(':', $selectvalues[0], 2);
             } else {
-                list($cohortid, $cohorttitle) = [$selectvalues[0], '', ''];
+                [$cohortid, $cohorttitle] = [$selectvalues[0], '', ''];
             }
         } else {
             $cohortid = '';
@@ -330,9 +325,9 @@ class enrol_ilios_edit_form extends moodleform {
         $selectvalues = $mform->getElementValue('selectlearnergroup');
         if (is_array($selectvalues)) {
             if (strstr($selectvalues[0], ':')) {
-                list($learnergroupid, $learnergrouptitle) = explode(':', $selectvalues[0], 2);
+                [$learnergroupid, $learnergrouptitle] = explode(':', $selectvalues[0], 2);
             } else {
-                list($learnergroupid, $learnergrouptitle) = [$selectvalues[0], '', ''];
+                [$learnergroupid, $learnergrouptitle] = [$selectvalues[0], '', ''];
             }
         } else {
             $learnergroupid = '';
@@ -348,7 +343,7 @@ class enrol_ilios_edit_form extends moodleform {
             $progel->load($schooloptions);
         } else {
             foreach ($schools as $school) {
-                $progel->addOption( $school->title, "$school->id:$school->title" );
+                $progel->addOption($school->title, "$school->id:$school->title");
             }
         }
 
@@ -389,8 +384,8 @@ class enrol_ilios_edit_form extends moodleform {
 
                 foreach ($cohorts as $cohort) {
                     $cohortoptions["$cohort->id:$cohort->title"] = $cohort->title
-                                                                 .' ('.count($cohort->learnerGroups).')'
-                                                                 .' ('.count($cohort->users).')';
+                                                                 . ' (' . count($cohort->learnerGroups) . ')'
+                                                                 . ' (' . count($cohort->users) . ')';
                 }
                 $progel->load($cohortoptions);
             }
@@ -404,9 +399,9 @@ class enrol_ilios_edit_form extends moodleform {
             $learnergroups = $ilios->get_learner_groups(['cohort' => $cid, 'parent' => 'null'], ['title' => "ASC"]);
             if (!empty($learnergroups)) {
                 foreach ($learnergroups as $group) {
-                    $learnergroupoptions["$group->id:$group->title"] = $group->title.
-                                                     ' ('. count($group->children) .')'.
-                                                     ' ('. count($group->users) .')';
+                    $learnergroupoptions["$group->id:$group->title"] = $group->title .
+                                                     ' (' . count($group->children) . ')' .
+                                                     ' (' . count($group->users) . ')';
                 }
                 $progel->load($learnergroupoptions);
             }
@@ -419,16 +414,17 @@ class enrol_ilios_edit_form extends moodleform {
 
             $subgroups = $ilios->get_learner_groups(["parent" => $gid], ["title" => "ASC"]);
             foreach ($subgroups as $subgroup) {
-                $subgroupoptions["$subgroup->id:$subgroup->title"] = $subgroup->title.
-                                                                   ' ('. count($subgroup->children) .')'.
-                                                                   ' ('. count($subgroup->users) .')';
+                $subgroupoptions["$subgroup->id:$subgroup->title"] = $subgroup->title .
+                                                                   ' (' . count($subgroup->children) . ')' .
+                                                                   ' (' . count($subgroup->users) . ')';
                 if (!empty($subgroup->children)) {
                     $processchildren = function ($parent) use (&$processchildren, &$subgroupoptions, $ilios) {
                         $subgrps = $ilios->get_learner_groups([ 'parent' => $parent->id], [ 'title' => "ASC"]);
                         foreach ($subgrps as $subgrp) {
-                            $subgroupoptions["$subgrp->id:$parent->title / $subgrp->title"] = $parent->title.' / '.$subgrp->title.
-                                                          ' ('. count($subgrp->children) .')'.
-                                                          ' ('. count($subgrp->users) .')';
+                            $subgroupoptions["$subgrp->id:$parent->title / $subgrp->title"]
+                                = $parent->title . ' / ' . $subgrp->title .
+                                ' (' . count($subgrp->children) . ')' .
+                                ' (' . count($subgrp->users) . ')';
                             if (!empty($subgrp->children)) {
                                 $processchildren($subgrp);
                             }
@@ -464,12 +460,12 @@ class enrol_ilios_edit_form extends moodleform {
 
         // Check for existing role.
         $selectgrouptype = 'cohort';
-        list($selectgroupid, $selecttitle) = explode(':', $data['selectcohort'], 2);
+        [$selectgroupid, $selecttitle] = explode(':', $data['selectcohort'], 2);
         if (!empty($data['selectlearnergroup'])) {
             $selectgrouptype = 'learnerGroup';
-            list($selectgroupid, $selecttitle) = explode(':', $data['selectlearnergroup'], 2);
+            [$selectgroupid, $selecttitle] = explode(':', $data['selectlearnergroup'], 2);
             if (!empty($data['selectsubgroup'])) {
-                list($selectgroupid, $selecttitle) = explode(':', $data['selectsubgroup'], 2);
+                [$selectgroupid, $selecttitle] = explode(':', $data['selectsubgroup'], 2);
             }
         }
 
@@ -482,7 +478,8 @@ class enrol_ilios_edit_form extends moodleform {
             'id' => $data['id'],
         ];
         // Customint2 could be NULL or 0 on the database.
-        if (empty($data['selectusertype'])
+        if (
+            empty($data['selectusertype'])
             && $DB->record_exists_select(
                 'enrol',
                 "roleid = :roleid AND customchar1 = :customchar1 AND customint1 = :customint1 "
@@ -492,12 +489,14 @@ class enrol_ilios_edit_form extends moodleform {
         ) {
             $errors['roleid'] = get_string('instanceexists', 'enrol_ilios');
         } else {
-            if ($DB->record_exists_select(
-                'enrol',
-                "roleid = :roleid AND customchar1 = :customchar1 AND customint1 = :customint1  " .
-                " AND customint2 = :customint2 AND courseid = :courseid AND enrol = 'ilios' AND id <> :id",
-                $params
-            )) {
+            if (
+                $DB->record_exists_select(
+                    'enrol',
+                    "roleid = :roleid AND customchar1 = :customchar1 AND customint1 = :customint1  " .
+                    " AND customint2 = :customint2 AND courseid = :courseid AND enrol = 'ilios' AND id <> :id",
+                    $params
+                )
+            ) {
                 $errors['roleid'] = get_string('instanceexists', 'enrol_ilios');
             }
         }

--- a/lib.php
+++ b/lib.php
@@ -28,7 +28,7 @@ use enrol_ilios\ilios;
 
 defined('MOODLE_INTERNAL') || die();
 
-require_once($CFG->libdir.'/filelib.php');
+require_once($CFG->libdir . '/filelib.php');
 
 /**
  * Ilios enrolment plugin implementation.
@@ -72,52 +72,50 @@ class enrol_ilios_plugin extends enrol_plugin {
 
         if (empty($instance)) {
             $enrol = $this->get_name();
-            return get_string('pluginshortname', 'enrol_'.$enrol);
-
+            return get_string('pluginshortname', 'enrol_' . $enrol);
         } else if (empty($instance->name)) {
             $enrol = $this->get_name();
-            $groupname = get_string('pluginshortname', 'enrol_'.$enrol);
+            $groupname = get_string('pluginshortname', 'enrol_' . $enrol);
             $syncinfo = json_decode($instance->customtext1);
 
             if (!empty($syncinfo)) {
                 $schooltitle = $syncinfo->school->title;
                 $programtitle = $syncinfo->program->shorttitle;
                 $cohorttitle = $syncinfo->cohort->title;
-                $groupname .= ": ". $schooltitle ."/".$programtitle."/".$cohorttitle;
+                $groupname .= ": " . $schooltitle . "/" . $programtitle . "/" . $cohorttitle;
                 if (isset($syncinfo->learnerGroup)) {
                     $grouptitle = $syncinfo->learnerGroup->title;
-                    $groupname .= '/'.$grouptitle;
+                    $groupname .= '/' . $grouptitle;
                 }
                 if (isset($syncinfo->subGroup)) {
                     $grouptitle = $syncinfo->subGroup->title;
-                    $groupname .= '/'.$grouptitle;
+                    $groupname .= '/' . $grouptitle;
                 }
             }
 
             if ($role = $DB->get_record('role', ['id' => $instance->roleid])) {
                 $role = role_get_name($role, context_course::instance($instance->courseid, IGNORE_MISSING));
                 if (empty($instance->customint2)) {
-                    $groupname .= ' (Learner => '.$role;
+                    $groupname .= ' (Learner => ' . $role;
                 } else {
-                    $groupname .= ' (Instructor => '.$role;
+                    $groupname .= ' (Instructor => ' . $role;
                 }
 
                 $groupid = $instance->customint6;
-                $group = groups_get_group( $groupid, 'name' );
+                $group = groups_get_group($groupid, 'name');
                 if (!empty($group) && isset($group->name)) {
                     $groupname .= ', ' . $group->name;
                 }
                 $groupname .= ')';
             } else {
                 $groupid = $instance->customint6;
-                $group = groups_get_group( $groupid, 'name' );
+                $group = groups_get_group($groupid, 'name');
                 if (!empty($group) && isset($group->name)) {
-                    $groupname .= ' (' . $group->name. ')';
+                    $groupname .= ' (' . $group->name . ')';
                 }
             }
 
             return $groupname;
-
         } else {
             return format_string($instance->name, true, ['context' => context_course::instance($instance->courseid)]);
         }
@@ -175,8 +173,12 @@ class enrol_ilios_plugin extends enrol_plugin {
 
         if (has_capability('enrol/ilios:config', $context)) {
             $editlink = new moodle_url("/enrol/ilios/edit.php", ['courseid' => $instance->courseid, 'id' => $instance->id]);
-            $icons[] = $OUTPUT->action_icon($editlink, new pix_icon('t/edit', get_string('edit'), 'core',
-                    ['class' => 'iconsmall']));
+            $icons[] = $OUTPUT->action_icon($editlink, new pix_icon(
+                't/edit',
+                get_string('edit'),
+                'core',
+                ['class' => 'iconsmall']
+            ));
         }
 
         return $icons;
@@ -305,8 +307,9 @@ class enrol_ilios_plugin extends enrol_plugin {
                     $trace->output(
                         "skipping: Cannot find campusId "
                         . $user->campusId
-                        . " that matches Moodle user field 'idnumber'."
-                        , 1);
+                        . " that matches Moodle user field 'idnumber'.",
+                        1
+                    );
                 } else {
                     $enrolleduserids[] = $userid = $iliosusers[$user->id]['id'];
 
@@ -348,16 +351,16 @@ class enrol_ilios_plugin extends enrol_plugin {
                             "changing enrollment status to '"
                             . ENROL_USER_ACTIVE
                             . "' from '{$ue->status}': userid $userid ==> courseid "
-                            . $instance->courseid
-                            , 1
+                            . $instance->courseid,
+                            1
                         );
                     } else {
                         $trace->output(
                             "enrolling with "
                             . ENROL_USER_ACTIVE
                             . " status: userid $userid ==> courseid "
-                            . $instance->courseid
-                            , 1
+                            . $instance->courseid,
+                            1
                         );
                     }
                 }
@@ -367,8 +370,8 @@ class enrol_ilios_plugin extends enrol_plugin {
             foreach ($suspendenrolments as $ue) {
                 $trace->output(
                     "Suspending enrollment for disabled Ilios user: userid "
-                    . " {$ue->userid} ==> courseid {$instance->courseid}."
-                    , 1
+                    . " {$ue->userid} ==> courseid {$instance->courseid}.",
+                    1
                 );
                 $this->update_user_enrol($instance, $ue->userid, ENROL_USER_SUSPENDED);
             }
@@ -376,7 +379,7 @@ class enrol_ilios_plugin extends enrol_plugin {
             // Unenrol as necessary.
             $trace->output(
                 "Unenrolling users from Course ID "
-                . $instance->courseid." with Role ID "
+                . $instance->courseid . " with Role ID "
                 . $instance->roleid
                 . " that no longer associate with Ilios Sync ID "
                 . $instance->id
@@ -388,7 +391,7 @@ class enrol_ilios_plugin extends enrol_plugin {
                   WHERE ue.enrolid = $instance->id";
 
             if (!empty($enrolleduserids)) {
-                $sql .= " AND ue.userid NOT IN ( ".implode(",", $enrolleduserids)." )";
+                $sql .= " AND ue.userid NOT IN ( " . implode(",", $enrolleduserids) . " )";
             }
 
             $rs = $DB->get_recordset_sql($sql);
@@ -399,8 +402,8 @@ class enrol_ilios_plugin extends enrol_plugin {
                     $trace->output(
                         "unenrolling: $ue->userid ==> "
                         . $instance->courseid
-                        . " via Ilios $synctype $syncid"
-                        , 1
+                        . " via Ilios $synctype $syncid",
+                        1
                     );
                 } else { // Would be ENROL_EXT_REMOVED_SUSPENDNOROLES.
                     // Just disable and ignore any changes.
@@ -417,8 +420,8 @@ class enrol_ilios_plugin extends enrol_plugin {
                             "suspending and unassigning all roles: userid "
                             . $ue->userid
                             . " ==> courseid "
-                            . $instance->courseid
-                            , 1
+                            . $instance->courseid,
+                            1
                         );
                     }
                 }
@@ -454,7 +457,7 @@ class enrol_ilios_plugin extends enrol_plugin {
         $rs = $DB->get_recordset_sql($sql, $params);
         foreach ($rs as $ra) {
             role_assign($ra->roleid, $ra->userid, $ra->contextid, 'enrol_ilios', $ra->itemid);
-            $trace->output("assigning role: $ra->userid ==> $ra->courseid as ".$allroles[$ra->roleid]->shortname, 1);
+            $trace->output("assigning role: $ra->userid ==> $ra->courseid as " . $allroles[$ra->roleid]->shortname, 1);
         }
         $rs->close();
 
@@ -475,7 +478,7 @@ class enrol_ilios_plugin extends enrol_plugin {
         $rs = $DB->get_recordset_sql($sql, $params);
         foreach ($rs as $ra) {
             role_unassign($ra->roleid, $ra->userid, $ra->contextid, 'enrol_ilios', $ra->itemid);
-            $trace->output("unassigning role: $ra->userid ==> $ra->courseid as ".$allroles[$ra->roleid]->shortname, 1);
+            $trace->output("unassigning role: $ra->userid ==> $ra->courseid as " . $allroles[$ra->roleid]->shortname, 1);
         }
         $rs->close();
 
@@ -624,7 +627,6 @@ class enrol_ilios_plugin extends enrol_plugin {
             $trace = new null_progress_trace();
             $this->sync($trace, $course->id);
             $trace->finished();
-
         } else if ($this->get_config('unenrolaction') == ENROL_EXT_REMOVED_SUSPENDNOROLES) {
             $instance = $DB->get_record(
                 'enrol',
@@ -647,7 +649,6 @@ class enrol_ilios_plugin extends enrol_plugin {
             $trace = new null_progress_trace();
             $this->sync($trace, $course->id);
             $trace->finished();
-
         } else {
             $step->set_mapping('enrol', $oldid, 0);
         }

--- a/settings.php
+++ b/settings.php
@@ -26,7 +26,6 @@
 defined('MOODLE_INTERNAL') || die();
 
 if ($ADMIN->fulltree) {
-
     // General settings.
     $settings->add(new admin_setting_heading('enrol_ilios_settings', '', get_string('pluginname_desc', 'enrol_ilios')));
 

--- a/tests/helper_test.php
+++ b/tests/helper_test.php
@@ -39,7 +39,6 @@ use enrol_ilios\tests\helper;
  * @covers     \enrol_ilios\tests\helper
  */
 final class helper_test extends basic_testcase {
-
     /**
      * Checks that the generator function creates a valid access token.
      * @return void

--- a/tests/ilios_test.php
+++ b/tests/ilios_test.php
@@ -48,7 +48,6 @@ use Psr\Http\Message\RequestInterface;
  * @covers     \enrol_ilios\ilios
  */
 final class ilios_test extends advanced_testcase {
-
     /**
      * Tests the happy path on get_schools().
      *
@@ -1055,7 +1054,8 @@ final class ilios_test extends advanced_testcase {
     public function test_get_with_filtering_and_sorting_criteria(
         array $filterby,
         array $sortby,
-        string $expectedquerystring): void {
+        string $expectedquerystring
+    ): void {
         $this->resetAfterTest();
         $accesstoken = helper::create_valid_ilios_api_access_token();
         set_config('apikey', $accesstoken, 'enrol_ilios');

--- a/tests/lib_test.php
+++ b/tests/lib_test.php
@@ -47,7 +47,6 @@ use text_progress_trace;
  * @covers \enrol_ilios_plugin
  */
 final class lib_test extends \advanced_testcase {
-
     /**
      * Tests the enrolment of Ilios cohort members into a Moodle course.
      */
@@ -144,8 +143,7 @@ final class lib_test extends \advanced_testcase {
                 'customint2' => 0,
                 'customchar1' => $synctype,
                 'roleid' => $studentrole->id,
-            ]
-        );
+            ]);
         $this->assertEquals(1, $DB->count_records('enrol', ['enrol' => 'ilios']));
         $instance = $DB->get_record('enrol', ['courseid' => $course->id, 'enrol' => 'ilios'], '*', MUST_EXIST);
         $this->assertEquals($studentrole->id, $instance->roleid);
@@ -274,7 +272,7 @@ final class lib_test extends \advanced_testcase {
         $this->assertStringContainsString(
             "Enrolling students to Course ID {$course->id} with Role ID "
                 . "{$studentrole->id} through Ilios Sync ID {$instance->id}.",
-                $output
+            $output
         );
         $this->assertStringContainsString('5 Ilios users found.', $output);
         $this->assertStringContainsString(
@@ -282,7 +280,7 @@ final class lib_test extends \advanced_testcase {
             $output
         );
         $this->assertStringContainsString(
-            "changing enrollment status to '". ENROL_USER_ACTIVE
+            "changing enrollment status to '" . ENROL_USER_ACTIVE
             . "' from '" . ENROL_USER_SUSPENDED . "': userid {$user6->id} ==> courseid {$course->id}",
             $output
         );
@@ -489,8 +487,7 @@ final class lib_test extends \advanced_testcase {
                 'customint2' => 0,
                 'customchar1' => $synctype,
                 'roleid' => $studentrole->id,
-            ]
-        );
+            ]);
         $this->assertEquals(1, $DB->count_records('enrol', ['enrol' => 'ilios']));
         $instance = $DB->get_record('enrol', ['courseid' => $course->id, 'enrol' => 'ilios'], '*', MUST_EXIST);
         $this->assertEquals($studentrole->id, $instance->roleid);
@@ -626,7 +623,7 @@ final class lib_test extends \advanced_testcase {
         );
         $this->assertEquals(1, substr_count($output, 'enrolling with ' . ENROL_USER_ACTIVE . ' status:'));
         $this->assertStringContainsString(
-            "changing enrollment status to '". ENROL_USER_ACTIVE
+            "changing enrollment status to '" . ENROL_USER_ACTIVE
             . "' from '" . ENROL_USER_SUSPENDED . "': userid {$user6->id} ==> courseid {$course->id}",
             $output
         );
@@ -913,7 +910,7 @@ final class lib_test extends \advanced_testcase {
         $context = context_course::instance($course->id);
 
         $users = array_map(
-            fn ($i) => $this->getDataGenerator()->create_user(['idnumber' => 'xx100000'. $i]),
+            fn ($i) => $this->getDataGenerator()->create_user(['idnumber' => 'xx100000' . $i]),
             range(1, 9)
         );
 
@@ -939,8 +936,7 @@ final class lib_test extends \advanced_testcase {
                 'customint2' => 1, // Ilios Instructors enrolment.
                 'customchar1' => $synctype,
                 'roleid' => $studentrole->id,
-            ]
-        );
+            ]);
         $this->assertEquals(1, $DB->count_records('enrol', ['enrol' => 'ilios']));
         $instance = $DB->get_record('enrol', ['courseid' => $course->id, 'enrol' => 'ilios'], '*', MUST_EXIST);
         $this->assertEquals($studentrole->id, $instance->roleid);
@@ -1001,7 +997,8 @@ final class lib_test extends \advanced_testcase {
         $this->assertEquals(
             'filters[id][]=1&filters[id][]=2&filters[id][]=3&filters[id][]=4'
             . '&filters[id][]=5&filters[id][]=6&filters[id][]=7&filters[id][]=8&filters[id][]=9',
-            urldecode($container[11]['request']->getUri()->getQuery()));
+            urldecode($container[11]['request']->getUri()->getQuery())
+        );
 
         // Check the logging output.
         $this->assertStringContainsString(
@@ -1085,8 +1082,7 @@ final class lib_test extends \advanced_testcase {
                 'customint2' => 0,
                 'customchar1' => 'learnerGroup',
                 'roleid' => $studentrole->id,
-            ]
-        );
+            ]);
         $this->assertEquals(1, $DB->count_records('enrol', ['enrol' => 'ilios']));
         $this->assertNotNull($DB->get_record('enrol', ['courseid' => $course->id, 'enrol' => 'ilios'], '*'));
 
@@ -1173,8 +1169,7 @@ final class lib_test extends \advanced_testcase {
                 'customint2' => 0,
                 'customchar1' => $synctype,
                 'roleid' => $studentrole->id,
-            ]
-        );
+            ]);
         $instance = $DB->get_record('enrol', ['courseid' => $course->id, 'enrol' => 'ilios'], '*', MUST_EXIST);
         $CFG->enrol_plugins_enabled = 'ilios';
         $plugin->enrol_user($instance, $user->id, $studentrole->id);
@@ -1384,8 +1379,7 @@ final class lib_test extends \advanced_testcase {
                 'customint2' => 0,
                 'customchar1' => $synctype,
                 'roleid' => $studentrole->id,
-            ]
-        );
+            ]);
         $instance = $DB->get_record('enrol', ['courseid' => $course->id, 'enrol' => 'ilios'], '*', MUST_EXIST);
         $CFG->enrol_plugins_enabled = 'ilios';
         $plugin->enrol_user($instance, $user->id, $studentrole->id);
@@ -1499,7 +1493,7 @@ final class lib_test extends \advanced_testcase {
         // Check the logging output.
         $this->assertStringContainsString('1 Ilios users found.', $output);
         $this->assertStringContainsString(
-            "changing enrollment status to '". ENROL_USER_ACTIVE
+            "changing enrollment status to '" . ENROL_USER_ACTIVE
             . "' from '" . ENROL_USER_SUSPENDED . "': userid {$user->id} ==> courseid {$course->id}",
             $output
         );
@@ -1598,8 +1592,7 @@ final class lib_test extends \advanced_testcase {
                 'customint2' => 0,
                 'customchar1' => $synctype,
                 'roleid' => $studentrole->id,
-            ]
-        );
+            ]);
         $instance = $DB->get_record('enrol', ['courseid' => $course->id, 'enrol' => 'ilios'], '*', MUST_EXIST);
         $CFG->enrol_plugins_enabled = 'ilios';
 
@@ -1743,8 +1736,7 @@ final class lib_test extends \advanced_testcase {
                 'customint2' => 0,
                 'customchar1' => $synctype,
                 'roleid' => $studentrole->id,
-            ]
-        );
+            ]);
         $instance = $DB->get_record('enrol', ['courseid' => $course->id, 'enrol' => 'ilios'], '*', MUST_EXIST);
         $CFG->enrol_plugins_enabled = 'ilios';
 
@@ -1835,8 +1827,7 @@ final class lib_test extends \advanced_testcase {
                 'customchar1' => $synctype,
                 'roleid' => $studentrole->id,
                 'status' => ENROL_INSTANCE_DISABLED,
-            ]
-        );
+            ]);
         $CFG->enrol_plugins_enabled = 'ilios';
 
         // Run enrolment sync.
@@ -1850,8 +1841,9 @@ final class lib_test extends \advanced_testcase {
         // There should be nothing in here but the task start/end notifications.
         $this->assertEquals(
             "Starting user enrolment synchronisation...\n"
-            . "...user enrolment synchronisation finished."
-            , trim($output));
+            . "...user enrolment synchronisation finished.",
+            trim($output)
+        );
 
         // No need to check enrolments, nothing happened during the sync.
     }
@@ -1909,8 +1901,7 @@ final class lib_test extends \advanced_testcase {
                 'customint2' => 0,
                 'customchar1' => $synctype,
                 'roleid' => $studentrole->id,
-            ]
-        );
+            ]);
         $instance = $DB->get_record('enrol', ['courseid' => $course->id, 'enrol' => 'ilios'], '*', MUST_EXIST);
         $CFG->enrol_plugins_enabled = 'ilios';
 
@@ -2053,8 +2044,7 @@ final class lib_test extends \advanced_testcase {
                 'customint2' => 0,
                 'customchar1' => $synctype,
                 'roleid' => $studentrole->id,
-            ]
-        );
+            ]);
         $CFG->enrol_plugins_enabled = 'ilios';
         $instance = $DB->get_record('enrol', ['courseid' => $course->id, 'enrol' => 'ilios'], '*', MUST_EXIST);
 


### PR DESCRIPTION
moodle-plugin-ci has updated its linting rules, this reformats the source code accordingly.

PHP code linted with `phpcs`.
and reformatted with `phpcbf`, except for `edit_form.php` which refused to get auto-reformatted with these tools. **that's the file that should be scrutinized during review.**

no functional changes.